### PR TITLE
Fixed server started message for invalid port

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -40,15 +40,16 @@ class ServeCommand extends Command
     public function handle()
     {
         chdir(public_path());
+        
+        $connection = @fsockopen($this->host(), $this->port());
 
-        $this->line("<info>Laravel development server started:</info> <http://{$this->host()}:{$this->port()}>");
-
-        passthru($this->serverCommand(), $status);
-
-        if ($status && $this->canTryAnotherPort()) {
+        if (is_resource($connection)) {
+            fclose($connection);
             $this->portOffset += 1;
-
             return $this->handle();
+        } else {
+            $this->line("<info>Laravel development server started:</info> <http://{$this->host()}:{$this->port()}>");
+            passthru($this->serverCommand(), $status);
         }
 
         return $status;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This will fix the #29231


As `passthru ( string $command [, int &$return_var ] ) : void` does not return any value on success, there seems to be currently no way to check if the server is failed to start based on the port number. This PR fixes the same by first checking if the port is occupied, if yes, try with another port until it connects and then displays the success message.